### PR TITLE
chore: Use windows target to build docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/ho-229/cloud-filter-rs"
 documentation = "https://docs.rs/cloud-filter"
 exclude = ["examples/"]
 
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+
 [dependencies]
 flagset = "0.4.5"
 widestring = "1.0.2"


### PR DESCRIPTION
This PR will use `x86_64-pc-windows-msvc` to build docs.

Ref: https://docs.rs/about/metadata
Last build log: https://docs.rs/crate/cloud-filter/0.0.2/builds/1282183